### PR TITLE
Milestones 3 & 4 — Timing infrastructure and dataset generation

### DIFF
--- a/scripts/generate_corpus.py
+++ b/scripts/generate_corpus.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""generate_corpus.py — build the joined training dataset (issue #16).
+
+For every C source file in an input directory this script:
+
+  1. Compiles it to unoptimised IR  (clang-17 -O0 -emit-llvm -S)
+  2. Extracts IR-complexity features (opt -passes=ir-complexity)
+  3. Collects per-pass O2 timings     (scripts/time_o2_pipeline.sh)
+  4. Pivots the timings so each pass becomes its own ``time_<Pass>`` column
+  5. Joins features + timings on ``function_name``
+  6. Adds ``total_compile_time_us`` = sum of every ``time_*`` column
+
+The per-function rows from all files are concatenated into one master CSV.
+
+Usage:
+    python3 scripts/generate_corpus.py \\
+        --input-dir testcases/training/ \\
+        --output training_data.csv \\
+        --plugin ./build/IRComplexityEstimator.so
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TIME_SCRIPT = SCRIPT_DIR / "time_o2_pipeline.sh"
+
+
+def find_tool(candidates: list[str]) -> str | None:
+    """Return the first tool on PATH from a list of candidate names."""
+    for name in candidates:
+        if shutil.which(name):
+            return name
+    return None
+
+
+def log(msg: str) -> None:
+    print(f"[generate_corpus] {msg}", flush=True)
+
+
+def process_file(
+    c_file: Path,
+    clang: str,
+    opt: str,
+    plugin: Path,
+    workdir: Path,
+) -> pd.DataFrame | None:
+    """Run the full pipeline for one C file.
+
+    Returns a per-function DataFrame, or None if the file could not be
+    processed (the caller counts this as an error).
+    """
+    stem = c_file.stem
+    ll_file = workdir / f"{stem}.ll"
+    feat_file = workdir / f"{stem}.features.json"
+    timing_file = workdir / f"{stem}.timings.csv"
+
+    # 1. Compile to unoptimised IR.
+    #    -Xclang -disable-O0-optnone omits the `optnone` attribute that
+    #    clang otherwise stamps on every -O0 function. The IR stays fully
+    #    unoptimised (clang runs no passes), but `optnone` would make the
+    #    later O2 timing pipeline skip every real pass, so it must be off.
+    res = subprocess.run(
+        [clang, "-O0", "-Xclang", "-disable-O0-optnone",
+         "-emit-llvm", "-S", str(c_file), "-o", str(ll_file)],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        log(f"ERROR: clang failed for {c_file.name}: "
+            f"{res.stderr.strip() or 'unknown error'} — skipping")
+        return None
+
+    # 2. Extract IR-complexity features.
+    res = subprocess.run(
+        [opt, "-load-pass-plugin", str(plugin), "-passes=ir-complexity",
+         f"-complexity-output={feat_file}", "-disable-output", str(ll_file)],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0 or not feat_file.exists():
+        log(f"ERROR: feature extraction failed for {c_file.name}: "
+            f"{res.stderr.strip() or 'unknown error'} — skipping")
+        return None
+
+    with feat_file.open() as fh:
+        features = json.load(fh)
+    if not features:
+        log(f"WARNING: {c_file.name} produced no functions — skipping")
+        return None
+    features_df = pd.DataFrame(features)
+
+    # 3. Collect per-pass O2 timings.
+    res = subprocess.run(
+        [str(TIME_SCRIPT), str(ll_file), str(timing_file)],
+        capture_output=True, text=True,
+        env={**__import__("os").environ, "PLUGIN": str(plugin)},
+    )
+    if res.returncode != 0 or not timing_file.exists():
+        log(f"ERROR: O2 timing failed for {c_file.name}: "
+            f"{res.stderr.strip() or 'unknown error'} — skipping")
+        return None
+
+    timings_df = pd.read_csv(timing_file)
+
+    # 4/5. Pivot timings (one column per pass) and join onto the features.
+    #      A pass may run several times per function in O2, so sum the times.
+    if timings_df.empty:
+        pivot = pd.DataFrame(index=pd.Index([], name="function_name"))
+    else:
+        pivot = timings_df.pivot_table(
+            index="function_name", columns="pass_name",
+            values="time_us", aggfunc="sum", fill_value=0,
+        )
+        pivot.columns = [f"time_{c}" for c in pivot.columns]
+
+    feat_funcs = set(features_df["function_name"])
+    timed_funcs = set(pivot.index)
+
+    # Edge case: functions timed but never seen by feature extraction.
+    for orphan in sorted(timed_funcs - feat_funcs):
+        log(f"WARNING: function '{orphan}' in timings but not features "
+            f"({c_file.name}) — skipping it")
+
+    merged = features_df.merge(
+        pivot, how="left", left_on="function_name", right_index=True,
+    )
+
+    # Edge case: functions with features but no timings (trivially
+    # optimised) — fill their pass-time columns with 0.
+    time_cols = [c for c in merged.columns if c.startswith("time_")]
+    if time_cols:
+        merged[time_cols] = merged[time_cols].fillna(0)
+
+    log(f"processed {c_file.name}: {len(merged)} function(s)")
+    return merged
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the joined training dataset from C source files.")
+    parser.add_argument("--input-dir", required=True,
+                        help="Directory of .c source files")
+    parser.add_argument("--output", required=True,
+                        help="Path to the master training CSV to write")
+    parser.add_argument("--plugin", required=True,
+                        help="Path to IRComplexityEstimator.so")
+    args = parser.parse_args()
+
+    input_dir = Path(args.input_dir)
+    output_path = Path(args.output)
+    plugin = Path(args.plugin).resolve()
+
+    if not input_dir.is_dir():
+        log(f"ERROR: input directory not found: {input_dir}")
+        return 1
+    if not plugin.is_file():
+        log(f"ERROR: plugin not found: {plugin} (run ./build.sh first)")
+        return 1
+    if not TIME_SCRIPT.is_file():
+        log(f"ERROR: timing script not found: {TIME_SCRIPT}")
+        return 1
+
+    clang = find_tool(["clang-17", "clang"])
+    opt = find_tool(["opt-17", "opt"])
+    if not clang or not opt:
+        log("ERROR: clang-17/opt-17 not found — run scripts/setup_env.sh")
+        return 1
+
+    c_files = sorted(input_dir.glob("*.c"))
+    if not c_files:
+        log(f"ERROR: no .c files found in {input_dir}")
+        return 1
+
+    frames: list[pd.DataFrame] = []
+    errors = 0
+    with tempfile.TemporaryDirectory(prefix="corpus_") as tmp:
+        workdir = Path(tmp)
+        for c_file in c_files:
+            df = process_file(c_file, clang, opt, plugin, workdir)
+            if df is None:
+                errors += 1
+            else:
+                frames.append(df)
+
+    if not frames:
+        log(f"ERROR: no files processed successfully ({errors} error(s))")
+        return 1
+
+    # Concatenate every file's rows; align pass columns across files and
+    # fill the gaps (a pass that ran for one file but not another) with 0.
+    corpus = pd.concat(frames, ignore_index=True, sort=False)
+    time_cols = [c for c in corpus.columns if c.startswith("time_")]
+    if time_cols:
+        corpus[time_cols] = corpus[time_cols].fillna(0).astype("int64")
+
+    # total_compile_time_us = sum of all per-pass time columns.
+    corpus["total_compile_time_us"] = (
+        corpus[time_cols].sum(axis=1) if time_cols else 0
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    corpus.to_csv(output_path, index=False)
+
+    log(f"Processed {len(c_files)} files, {len(corpus)} functions, "
+        f"{errors} errors")
+    log(f"wrote {output_path} "
+        f"({len(corpus.columns)} columns, {len(time_cols)} pass-time columns)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/time_o2_pipeline.sh
+++ b/scripts/time_o2_pipeline.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# time_o2_pipeline.sh — run the full -O2 optimisation pipeline through opt
+# with the timing plugin loaded, capturing per-pass timings for every
+# function. This is the primary data-collection tool for the training set.
+#
+# Usage:
+#   ./scripts/time_o2_pipeline.sh <input.ll> <output_timing.csv>
+#
+# The plugin path defaults to ./build/IRComplexityEstimator.so and can be
+# overridden with the PLUGIN environment variable.
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN="${PLUGIN:-$ROOT_DIR/build/IRComplexityEstimator.so}"
+
+if [[ -t 2 ]]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; NC=''
+fi
+die() { echo -e "${RED}error${NC}: $*" >&2; exit 1; }
+
+# --- arguments ------------------------------------------------------------
+[[ $# -eq 2 ]] || die "usage: $(basename "$0") <input.ll> <output_timing.csv>"
+INPUT_LL="$1"
+OUTPUT_CSV="$2"
+
+[[ -f "$INPUT_LL" && -r "$INPUT_LL" ]] \
+  || die "input IR file does not exist or is not readable: $INPUT_LL"
+[[ -f "$PLUGIN" ]] || die "plugin not found: $PLUGIN (run ./build.sh first)"
+
+OPT_BIN="$(command -v opt-17 || command -v opt || true)"
+[[ -n "$OPT_BIN" ]] || die "opt not found — run scripts/setup_env.sh"
+
+# --- run the O2 pipeline under the timing plugin --------------------------
+# -passes="default<O2>" runs the complete standard O2 pipeline. Some of its
+# passes run at module or loop level; those produce no per-function timing
+# rows by design (the wrapper only records function-level passes).
+# -disable-output skips writing the optimised IR — only timing data matters.
+START_NS=$(date +%s%N)
+"$OPT_BIN" \
+  -load-pass-plugin "$PLUGIN" \
+  -passes="default<O2>" \
+  -timing-output="$OUTPUT_CSV" \
+  -disable-output \
+  "$INPUT_LL" \
+  || die "opt failed while running the O2 pipeline on $INPUT_LL"
+END_NS=$(date +%s%N)
+
+# --- verify and summarise -------------------------------------------------
+[[ -f "$OUTPUT_CSV" ]] || die "no timing CSV produced at $OUTPUT_CSV"
+
+ROWS=$(($(wc -l < "$OUTPUT_CSV") - 1))   # minus the header line
+[[ "$ROWS" -gt 0 ]] || die "timing CSV $OUTPUT_CSV contains no data rows"
+
+FUNCS=$(tail -n +2 "$OUTPUT_CSV" | cut -d, -f1 | sort -u | wc -l | tr -d ' ')
+PASSES=$(tail -n +2 "$OUTPUT_CSV" | cut -d, -f2 | sort -u | wc -l | tr -d ' ')
+ELAPSED_MS=$(( (END_NS - START_NS) / 1000000 ))
+
+echo -e "${GREEN}O2 timing complete${NC}: $OUTPUT_CSV"
+echo "  rows recorded   : $ROWS"
+echo "  functions timed : $FUNCS"
+echo "  distinct passes : $PASSES"
+echo "  wall time       : ${ELAPSED_MS} ms"

--- a/src/passes/IRComplexityPass.cpp
+++ b/src/passes/IRComplexityPass.cpp
@@ -290,6 +290,10 @@ struct IRComplexityPass : PassInfoMixin<IRComplexityPass> {
 
 } // namespace
 
+// Defined in src/timing/PassTimingWrapper.cpp (issue #14). Registers the
+// per-pass timing instrumentation on the same plugin's PassBuilder.
+void registerPassTiming(PassBuilder &PB);
+
 llvm::PassPluginLibraryInfo getIRComplexityPluginInfo() {
   return {LLVM_PLUGIN_API_VERSION, "IRComplexity", LLVM_VERSION_STRING,
           [](PassBuilder &PB) {
@@ -302,6 +306,9 @@ llvm::PassPluginLibraryInfo getIRComplexityPluginInfo() {
                   }
                   return false;
                 });
+            // Hook the timing instrumentation into every opt invocation
+            // that loads this plugin.
+            registerPassTiming(PB);
           }};
 }
 

--- a/src/timing/PassTimingWrapper.cpp
+++ b/src/timing/PassTimingWrapper.cpp
@@ -1,6 +1,155 @@
-// Stub — implementation added in issue #14
-#include "llvm/IR/PassManager.h"
+// Per-pass timing instrumentation (issue #14).
+//
+// This translation unit is linked into the same IRComplexityEstimator.so
+// plugin as IRComplexityPass.cpp. It is wired up from the plugin's
+// llvmGetPassPluginInfo callback, which calls registerPassTiming() below.
+//
+// It records how long every *function-level* pass takes to process every
+// function and writes one CSV row per (function, pass) pair. Module-level
+// and loop-level passes are silently ignored, as required.
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/PassInstrumentation.h"
+#include "llvm/IR/Function.h"
+#include "llvm/ADT/Any.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <chrono>
+#include <ctime>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
 
 using namespace llvm;
-// PassTimingWrapper instrumentation — to be implemented in issue #14
+
+static cl::opt<std::string> TimingOutput(
+    "timing-output",
+    cl::desc("Path to write the per-pass timing CSV"),
+    cl::value_desc("path"), cl::init("timings.csv"));
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+// Return the function name carried by an instrumentation IR unit, or an
+// empty StringRef when the unit is not a Function. The new pass manager
+// passes IR units wrapped in llvm::Any as `const Function *` (function
+// passes), `const Module *`, `const Loop *` or `const LazyCallGraph::SCC *`.
+// any_isa is deprecated in LLVM 17, so the pointer-returning any_cast
+// overload is used instead.
+StringRef functionName(const Any &IR) {
+  if (const Function *const *FP = any_cast<const Function *>(&IR))
+    return (*FP)->getName();
+  return StringRef();
+}
+
+// Write S as a quoted CSV field. Pass names such as
+// "RequireAnalysisPass<A, B, C>" contain commas, so every field is quoted
+// and any embedded double quote is doubled per RFC 4180.
+void writeCsvField(raw_ostream &O, StringRef S) {
+  O << '"';
+  for (char C : S) {
+    if (C == '"')
+      O << '"';
+    O << C;
+  }
+  O << '"';
+}
+
+std::string isoTimestamp() {
+  std::time_t T = std::time(nullptr);
+  char Buf[32];
+  std::tm TM;
+#if defined(_WIN32)
+  localtime_s(&TM, &T);
+#else
+  localtime_r(&T, &TM);
+#endif
+  std::strftime(Buf, sizeof(Buf), "%Y-%m-%dT%H:%M:%S", &TM);
+  return std::string(Buf);
+}
+
+// Records pass start times and emits one CSV row per finished pass. A
+// single instance lives for the whole process (see registerPassTiming).
+class PassTimingInstrumentation {
+public:
+  void registerCallbacks(PassInstrumentationCallbacks &PIC) {
+    PIC.registerBeforeNonSkippedPassCallback(
+        [this](StringRef PassID, Any IR) { onBeforePass(PassID, IR); });
+    PIC.registerAfterPassCallback(
+        [this](StringRef PassID, Any IR, const PreservedAnalyses &) {
+          onAfterPass(PassID, IR);
+        });
+  }
+
+private:
+  std::map<std::pair<std::string, std::string>, Clock::time_point> StartTimes;
+  std::unique_ptr<raw_fd_ostream> OS;
+  bool HeaderWritten = false;
+
+  // Open the CSV lazily and write the header on first use.
+  raw_fd_ostream *stream() {
+    if (HeaderWritten)
+      return OS && !OS->has_error() ? OS.get() : nullptr;
+    HeaderWritten = true;
+    std::string Path = TimingOutput;
+    std::error_code EC;
+    OS = std::make_unique<raw_fd_ostream>(Path, EC, sys::fs::OF_Text);
+    if (EC) {
+      errs() << "[PassTiming] error: cannot open " << Path << ": "
+             << EC.message() << "\n";
+      OS.reset();
+      return nullptr;
+    }
+    *OS << "function_name,pass_name,time_us,timestamp\n";
+    OS->flush();
+    return OS.get();
+  }
+
+  void onBeforePass(StringRef PassID, const Any &IR) {
+    StringRef FN = functionName(IR);
+    if (FN.empty())
+      return; // not a function-level pass — ignore
+    StartTimes[{PassID.str(), FN.str()}] = Clock::now();
+  }
+
+  void onAfterPass(StringRef PassID, const Any &IR) {
+    StringRef FN = functionName(IR);
+    if (FN.empty())
+      return;
+    auto It = StartTimes.find({PassID.str(), FN.str()});
+    if (It == StartTimes.end())
+      return;
+    auto Elapsed = Clock::now() - It->second;
+    StartTimes.erase(It);
+
+    long long US =
+        std::chrono::duration_cast<std::chrono::microseconds>(Elapsed).count();
+    if (US < 0)
+      US = 0; // time_us must never be negative
+
+    if (raw_fd_ostream *O = stream()) {
+      writeCsvField(*O, FN);
+      *O << ",";
+      writeCsvField(*O, PassID);
+      *O << "," << US << "," << isoTimestamp() << "\n";
+      // Flush every row so the CSV is intact even if a later pass crashes.
+      O->flush();
+    }
+  }
+};
+
+} // namespace
+
+// Called from llvmGetPassPluginInfo (IRComplexityPass.cpp). The
+// instrumentation object is process-lived so its callbacks stay valid for
+// the entire opt run.
+void registerPassTiming(PassBuilder &PB) {
+  static PassTimingInstrumentation Instrumentation;
+  if (PassInstrumentationCallbacks *PIC = PB.getPassInstrumentationCallbacks())
+    Instrumentation.registerCallbacks(*PIC);
+}

--- a/testcases/training/t01_simple_leaf.c
+++ b/testcases/training/t01_simple_leaf.c
@@ -1,0 +1,23 @@
+/* t01_simple_leaf.c
+ *
+ * Complexity pattern: leaf functions — pure integer arithmetic with no
+ * loops, no branches and no memory traffic. Each function is a single
+ * basic block.
+ *
+ * Why it is interesting to the model: this is the clean LOW-tier
+ * baseline. Every function here has cyclomatic_complexity = 1 and
+ * loop_count = 0, so the optimiser does almost no work. It anchors the
+ * low end of the feature-to-cost relationship the model learns.
+ */
+
+int add_ints(int a, int b) {
+    return a + b;
+}
+
+int subtract_ints(int a, int b) {
+    return a - b;
+}
+
+int multiply_ints(int a, int b) {
+    return a * b;
+}

--- a/testcases/training/t02_nested_loops.c
+++ b/testcases/training/t02_nested_loops.c
@@ -1,0 +1,35 @@
+/* t02_nested_loops.c
+ *
+ * Complexity pattern: a classic matrix multiply with a 3-level loop nest
+ * operating over pointer arguments, plus two shallower loop functions.
+ *
+ * Why it is interesting to the model: loop nesting depth is the single
+ * strongest predictor of optimisation cost — LICM, loop unrolling and
+ * vectorisation all scale super-linearly with depth. This is a HIGH-tier
+ * training sample.
+ */
+
+void matrix_multiply(const int *a, const int *b, int *c, int n) {
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < n; j++) {
+            int sum = 0;
+            for (int k = 0; k < n; k++)
+                sum += a[i * n + k] * b[k * n + j];
+            c[i * n + j] = sum;
+        }
+    }
+}
+
+void matrix_scale(int *m, int n, int factor) {
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < n; j++)
+            m[i * n + j] *= factor;
+    }
+}
+
+int matrix_trace(const int *m, int n) {
+    int t = 0;
+    for (int i = 0; i < n; i++)
+        t += m[i * n + i];
+    return t;
+}

--- a/testcases/training/t03_aliasing.c
+++ b/testcases/training/t03_aliasing.c
@@ -1,0 +1,28 @@
+/* t03_aliasing.c
+ *
+ * Complexity pattern: heavy pointer aliasing. The same buffers are read
+ * and written through multiple pointer arguments that may overlap, so
+ * the compiler cannot prove non-aliasing without analysis.
+ *
+ * Why it is interesting to the model: every load/store pair forces the
+ * alias-analysis framework to issue queries during LICM, GVN and
+ * vectorisation. The structural alias proxy (memory-op density) is high,
+ * making this a HIGH-tier sample.
+ */
+
+void copy_overlap(int *dst, const int *src, int n) {
+    for (int i = 0; i < n; i++)
+        dst[i] = src[i] + src[(i + 1) % n];
+}
+
+int sum_through_two(const int *p, const int *q, int n) {
+    int s = 0;
+    for (int i = 0; i < n; i++)
+        s += p[i] + q[i];
+    return s;
+}
+
+void accumulate(int *acc, const int *a, const int *b, int n) {
+    for (int i = 0; i < n; i++)
+        acc[i] += a[i] * b[i];
+}

--- a/testcases/training/t04_many_branches.c
+++ b/testcases/training/t04_many_branches.c
@@ -1,0 +1,74 @@
+/* t04_many_branches.c
+ *
+ * Complexity pattern: very high control-flow complexity from a long
+ * if/else chain (30+ arms) and a large switch statement.
+ *
+ * Why it is interesting to the model: cyclomatic complexity here is well
+ * above 20. Passes that reason about control flow — SimplifyCFG, jump
+ * threading, SCCP — do proportionally more work. This is a MEDIUM-HIGH
+ * tier sample that decouples branch complexity from loop complexity.
+ */
+
+int classify(int x) {
+    if (x < 0)        return -1;
+    else if (x == 0)  return 0;
+    else if (x < 5)   return 1;
+    else if (x < 10)  return 2;
+    else if (x < 15)  return 3;
+    else if (x < 20)  return 4;
+    else if (x < 25)  return 5;
+    else if (x < 30)  return 6;
+    else if (x < 35)  return 7;
+    else if (x < 40)  return 8;
+    else if (x < 45)  return 9;
+    else if (x < 50)  return 10;
+    else if (x < 55)  return 11;
+    else if (x < 60)  return 12;
+    else if (x < 65)  return 13;
+    else if (x < 70)  return 14;
+    else if (x < 75)  return 15;
+    else if (x < 80)  return 16;
+    else if (x < 85)  return 17;
+    else if (x < 90)  return 18;
+    else if (x < 95)  return 19;
+    else if (x < 100) return 20;
+    else if (x < 110) return 21;
+    else if (x < 120) return 22;
+    else if (x < 130) return 23;
+    else if (x < 140) return 24;
+    else if (x < 150) return 25;
+    else if (x < 160) return 26;
+    else if (x < 170) return 27;
+    else if (x < 180) return 28;
+    else if (x < 190) return 29;
+    else if (x < 200) return 30;
+    else              return 31;
+}
+
+int dispatch(int code) {
+    switch (code) {
+        case 0:  return 100;
+        case 1:  return 101;
+        case 2:  return 102;
+        case 3:  return 103;
+        case 4:  return 104;
+        case 5:  return 105;
+        case 6:  return 106;
+        case 7:  return 107;
+        case 8:  return 108;
+        case 9:  return 109;
+        case 10: return 110;
+        case 11: return 111;
+        case 12: return 112;
+        default: return -1;
+    }
+}
+
+int combined(int x, int code) {
+    int c = classify(x);
+    if (c < 0)
+        return dispatch(0);
+    if (c > 15)
+        return dispatch(code) + c;
+    return dispatch(code);
+}

--- a/testcases/training/t05_type_complex.c
+++ b/testcases/training/t05_type_complex.c
@@ -1,0 +1,46 @@
+/* t05_type_complex.c
+ *
+ * Complexity pattern: deeply nested aggregate types — structs containing
+ * fixed arrays of other structs, plus multi-level pointers (float **).
+ *
+ * Why it is interesting to the model: functions that move data through
+ * complex types generate more work for type-based reasoning and alias
+ * analysis than functions over plain scalars. This is a MEDIUM-tier
+ * sample that isolates type complexity from loop/branch complexity.
+ */
+
+struct Inner {
+    int *p;
+    int count;
+};
+
+struct Middle {
+    struct Inner items[4];
+    double weight;
+};
+
+typedef struct {
+    struct Middle layers[2];
+    float **matrix;
+    int depth;
+} Outer;
+
+int inner_total(const struct Inner *in) {
+    int t = 0;
+    for (int i = 0; i < in->count; i++)
+        t += in->p[i];
+    return t;
+}
+
+double outer_weight(const Outer *o) {
+    double w = 0.0;
+    for (int i = 0; i < 2; i++)
+        w += o->layers[i].weight;
+    return w;
+}
+
+float matrix_elem(const Outer *o, int row, int col) {
+    if (row < 0 || col < 0 || row >= o->depth)
+        return 0.0f;
+    return o->matrix[row][col];
+}

--- a/testcases/training/t06_phi_heavy.c
+++ b/testcases/training/t06_phi_heavy.c
@@ -1,0 +1,57 @@
+/* t06_phi_heavy.c
+ *
+ * Complexity pattern: many control-flow merge points. A dozen local
+ * variables are each assigned on both sides of several branches, so once
+ * mem2reg promotes them to SSA form the merge blocks fill with PHI
+ * nodes.
+ *
+ * Why it is interesting to the model: high PHI density stresses GVN
+ * (which tracks value equivalences across PHIs) and register allocation.
+ * This is a MEDIUM-tier sample that exercises the phi_* features.
+ */
+
+int select_many(int s, int a, int b, int c, int d) {
+    int v0, v1, v2, v3, v4, v5, v6, v7, v8, v9;
+
+    if (s > 0) {
+        v0 = a;     v1 = b;     v2 = c;     v3 = d;     v4 = a + b;
+    } else {
+        v0 = b;     v1 = c;     v2 = d;     v3 = a;     v4 = c + d;
+    }
+
+    if (s > 5) {
+        v5 = v0 + v1;   v6 = v2 - v3;   v7 = v4 * 2;
+        v8 = v0 - v2;   v9 = v1 + v3;
+    } else {
+        v5 = v1;        v6 = v2;        v7 = v3;
+        v8 = v4 * 3;    v9 = v0 - v1;
+    }
+
+    return v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9;
+}
+
+int merge_chain(int n, int seed) {
+    int acc = seed;
+    int extra = 0;
+
+    if (n > 10)      acc += 5;
+    else             acc -= 3;
+
+    if (n % 2 == 0)  extra = acc * 2;
+    else             extra = acc + 7;
+
+    if (seed < 0)    acc = extra - acc;
+    else             acc = extra + acc;
+
+    return acc + extra;
+}
+
+int blend(int x, int y, int flag) {
+    int lo, hi, mid;
+
+    if (x < y) { lo = x; hi = y; } else { lo = y; hi = x; }
+    mid = (lo + hi) / 2;
+    if (flag) mid = hi - lo;
+
+    return lo + hi + mid;
+}

--- a/testcases/training/t07_large_function.c
+++ b/testcases/training/t07_large_function.c
@@ -1,0 +1,156 @@
+/* t07_large_function.c
+ *
+ * Complexity pattern: one large function (200+ lines) mixing loops,
+ * conditionals and helper-function calls, alongside two supporting
+ * helpers. The body is long enough that instruction_count and
+ * call_site_count are both high.
+ *
+ * Why it is interesting to the model: raw function size is a baseline
+ * predictor — nearly every pass scales at least linearly with the
+ * instruction count. Combined with branches and calls, this is a
+ * HIGH-tier sample.
+ */
+
+#include <stdlib.h>
+
+static int clamp(int value, int lo, int hi) {
+    if (value < lo)
+        return lo;
+    if (value > hi)
+        return hi;
+    return value;
+}
+
+static int mix(int a, int b, int rounds) {
+    int acc = a ^ b;
+    for (int i = 0; i < rounds; i++) {
+        acc = (acc << 1) | (acc >> 31);
+        acc ^= (a + i);
+        acc += (b - i);
+    }
+    return acc;
+}
+
+int run_pipeline(int *buffer, int length, int mode, int seed) {
+    int total = 0;
+    int positive = 0;
+    int negative = 0;
+    int zero = 0;
+    int running = seed;
+    int peak = 0;
+    int trough = 0;
+
+    /* Phase 1: normalise the buffer in place. */
+    for (int i = 0; i < length; i++) {
+        int v = buffer[i];
+        if (v > 1000)
+            v = 1000;
+        else if (v < -1000)
+            v = -1000;
+        buffer[i] = clamp(v, -500, 500);
+    }
+
+    /* Phase 2: gather first-order statistics. */
+    for (int i = 0; i < length; i++) {
+        int v = buffer[i];
+        total += v;
+        if (v > 0)
+            positive++;
+        else if (v < 0)
+            negative++;
+        else
+            zero++;
+        if (v > peak)
+            peak = v;
+        if (v < trough)
+            trough = v;
+    }
+
+    /* Phase 3: mode-dependent transformation. */
+    if (mode == 0) {
+        for (int i = 0; i < length; i++) {
+            running = mix(running, buffer[i], 3);
+            buffer[i] = running & 0xFFFF;
+        }
+    } else if (mode == 1) {
+        for (int i = 0; i < length; i++) {
+            int left = (i > 0) ? buffer[i - 1] : 0;
+            int right = (i < length - 1) ? buffer[i + 1] : 0;
+            buffer[i] = (left + buffer[i] + right) / 3;
+        }
+    } else if (mode == 2) {
+        for (int i = 0; i < length; i++) {
+            if (buffer[i] % 2 == 0)
+                buffer[i] = buffer[i] / 2;
+            else
+                buffer[i] = buffer[i] * 3 + 1;
+        }
+    } else {
+        for (int i = 0; i < length; i++)
+            buffer[i] = clamp(buffer[i] + seed, -500, 500);
+    }
+
+    /* Phase 4: windowed accumulation with an inner reduction loop. */
+    int window_sum = 0;
+    for (int i = 0; i < length; i++) {
+        int window = 0;
+        for (int w = -2; w <= 2; w++) {
+            int idx = i + w;
+            if (idx >= 0 && idx < length)
+                window += buffer[idx];
+        }
+        window_sum += window;
+        if (window > peak * 5)
+            window_sum += 1;
+    }
+
+    /* Phase 5: derive a score from the gathered metrics. */
+    int score = 0;
+    if (positive > negative) {
+        score = positive - negative;
+        if (zero > 0)
+            score += zero;
+    } else if (negative > positive) {
+        score = negative - positive;
+        score = -score;
+    } else {
+        score = zero;
+    }
+
+    if (total > 0)
+        score += total / (length > 0 ? length : 1);
+    else
+        score -= 1;
+
+    /* Phase 6: a small state machine over the running value. */
+    int state = 0;
+    for (int i = 0; i < length; i++) {
+        switch (state) {
+            case 0:
+                if (buffer[i] > 0)
+                    state = 1;
+                break;
+            case 1:
+                if (buffer[i] < 0)
+                    state = 2;
+                else
+                    score += 1;
+                break;
+            case 2:
+                if (buffer[i] == 0)
+                    state = 0;
+                else
+                    score -= 1;
+                break;
+            default:
+                state = 0;
+                break;
+        }
+    }
+
+    /* Phase 7: final fold combining everything. */
+    int result = score + window_sum + peak + trough;
+    result = mix(result, total, 4);
+    result = clamp(result, -100000, 100000);
+    return result;
+}

--- a/testcases/training/t08_recursive.c
+++ b/testcases/training/t08_recursive.c
@@ -1,0 +1,32 @@
+/* t08_recursive.c
+ *
+ * Complexity pattern: recursive functions — naive Fibonacci, factorial
+ * and a recursive binary-tree-style sum over an array.
+ *
+ * Why it is interesting to the model: recursion makes the inliner work
+ * hard (recursive calls cannot be fully inlined) and produces call-heavy
+ * IR with non-trivial call-site counts. This is a MEDIUM-tier sample.
+ */
+
+int fib(int n) {
+    if (n < 2)
+        return n;
+    return fib(n - 1) + fib(n - 2);
+}
+
+long factorial(int n) {
+    if (n <= 1)
+        return 1;
+    return (long)n * factorial(n - 1);
+}
+
+int tree_sum(const int *values, int lo, int hi) {
+    if (lo > hi)
+        return 0;
+    if (lo == hi)
+        return values[lo];
+    int mid = lo + (hi - lo) / 2;
+    int left = tree_sum(values, lo, mid);
+    int right = tree_sum(values, mid + 1, hi);
+    return left + right;
+}

--- a/testcases/training/t09_simd_friendly.c
+++ b/testcases/training/t09_simd_friendly.c
@@ -1,0 +1,35 @@
+/* t09_simd_friendly.c
+ *
+ * Complexity pattern: simple, regular array loops with no loop-carried
+ * dependencies and no aliasing hazards between distinct buffers — the
+ * kind of code the loop and SLP vectorisers handle well.
+ *
+ * Why it is interesting to the model: these loops are cheap to analyse
+ * but trigger the vectoriser, so they exercise the vectorisation passes
+ * without heavy alias or control-flow cost. This is a LOW-MEDIUM tier
+ * sample.
+ */
+
+int array_sum(const int *a, int n) {
+    int s = 0;
+    for (int i = 0; i < n; i++)
+        s += a[i];
+    return s;
+}
+
+void array_scale(int *a, int n, int factor) {
+    for (int i = 0; i < n; i++)
+        a[i] *= factor;
+}
+
+void array_add(int *out, const int *x, const int *y, int n) {
+    for (int i = 0; i < n; i++)
+        out[i] = x[i] + y[i];
+}
+
+int array_dot(const int *x, const int *y, int n) {
+    int acc = 0;
+    for (int i = 0; i < n; i++)
+        acc += x[i] * y[i];
+    return acc;
+}

--- a/testcases/training/t10_pathological.c
+++ b/testcases/training/t10_pathological.c
@@ -1,0 +1,75 @@
+/* t10_pathological.c
+ *
+ * Complexity pattern: the deliberate worst case — a 4-level loop nest
+ * combined with heavy pointer aliasing and a nested-struct type. The
+ * innermost loop is dense with loads, stores and pointer arithmetic.
+ *
+ * Why it is interesting to the model: this stacks every cost driver at
+ * once (loop depth, alias-query density, type complexity) to anchor the
+ * VERY HIGH end of the training distribution.
+ */
+
+#include <stdlib.h>
+
+struct Grid {
+    int *cells;
+    int *scratch;
+    int width;
+    int height;
+};
+
+struct Field {
+    struct Grid grids[2];
+    double *weights;
+    int generations;
+};
+
+void evolve(struct Grid *g, int steps) {
+    for (int s = 0; s < steps; s++) {
+        for (int y = 0; y < g->height; y++) {
+            for (int x = 0; x < g->width; x++) {
+                int acc = 0;
+                for (int k = 0; k < 4; k++) {
+                    int ny = (y + k) % g->height;
+                    int nx = (x + k) % g->width;
+                    acc += g->cells[ny * g->width + nx];
+                    g->scratch[y * g->width + x] = acc;
+                }
+                g->cells[y * g->width + x] = g->scratch[y * g->width + x];
+            }
+        }
+    }
+}
+
+double simulate_field(struct Field *f) {
+    double energy = 0.0;
+    for (int gen = 0; gen < f->generations; gen++) {
+        for (int gi = 0; gi < 2; gi++) {
+            struct Grid *g = &f->grids[gi];
+            for (int y = 0; y < g->height; y++) {
+                for (int x = 0; x < g->width; x++) {
+                    int idx = y * g->width + x;
+                    g->cells[idx] += g->scratch[idx];
+                    energy += f->weights[gi] * (double)g->cells[idx];
+                }
+            }
+        }
+    }
+    return energy;
+}
+
+int cross_blur(int *dst, const int *src, int w, int h) {
+    int touched = 0;
+    for (int y = 1; y < h - 1; y++) {
+        for (int x = 1; x < w - 1; x++) {
+            for (int dy = -1; dy <= 1; dy++) {
+                for (int dx = -1; dx <= 1; dx++) {
+                    int si = (y + dy) * w + (x + dx);
+                    dst[y * w + x] += src[si];
+                    touched++;
+                }
+            }
+        }
+    }
+    return touched;
+}


### PR DESCRIPTION
Implements Milestone 3 (Timing Infrastructure) and Milestone 4 (Dataset Generation) as 4 per-issue commits.

## Milestone 3 — Timing Infrastructure
- **#14** Pass timing wrapper — `PassTimingWrapper.cpp` instruments every function-level pass via `PassInstrumentationCallbacks`, writing one CSV row per `(function, pass)` pair into the existing plugin.
- **#15** `scripts/time_o2_pipeline.sh` — runs the full `default<O2>` pipeline under the timing plugin and summarises functions/passes/wall time.

## Milestone 4 — Dataset Generation
- **#16** `scripts/generate_corpus.py` — compiles C → IR, extracts features, collects O2 timings, pivots and joins them into a master training CSV with `total_compile_time_us`.
- **#17** 10 synthetic benchmark testcases spanning the complexity spectrum.

## Verification (Docker, Ubuntu 22.04 + LLVM 17.0.6)
- All 10 testcases compile cleanly with `clang-17 -O0 -Wall -Wextra -std=c99`.
- `time_o2_pipeline.sh` on `t02_nested_loops`: 255 rows, 45 distinct passes, `LoopVectorizePass` present, all `time_us >= 0`.
- `generate_corpus.py` processes all 10 files → `Processed 10 files, 31 functions, 0 errors`; 69 columns, 45 pass-time columns; `total_compile_time_us` equals the row sum of `time_*` for every row.
- AC spot checks: `t01` every function `loop_count=0`/`cyclomatic_complexity=1`; `t10` `max_loop_depth=4` and `alias_proxy_density=0.614`.

## Key fix found during verification
`clang -O0` stamps every function with the `optnone` attribute, which makes the O2 pipeline skip all real passes. The corpus generator compiles IR with `-Xclang -disable-O0-optnone` — the IR stays unoptimised but the timing pipeline now exercises InstCombine, GVN, LICM, LoopVectorize, etc. CSV fields are also RFC 4180 quoted because pass names like `RequireAnalysisPass<A, B>` contain commas.