### PR TITLE
Milestone 7 — Evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ timings.csv
 docs/feature_importance.png
 docs/correlation_heatmap.png
 docs/feature_importance_report.md
+docs/evaluation_results.json
+docs/evaluation_plots/
+docs/savings_report.md
 
 # Environment
 .env

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""evaluate.py — comprehensive evaluation suite (issue #24).
+
+Produces every number that goes into EVALUATION.md.
+
+Mode 1 — Prediction accuracy: for each function in the held-out
+testcases/evaluation/ corpus, compare the model's predicted compile time
+against the time actually measured by running opt -O2 with the timing
+plugin (R2, MAE, RMSE, MAPE, and per-pass MAPE).
+
+Mode 2 — Adaptive pipeline effectiveness: compare baseline full-O2
+compilation against the adaptive pipeline, both in compile-time savings
+and in the execution speed (code quality) of the resulting binaries.
+
+Outputs:
+  docs/evaluation_results.json
+  docs/evaluation_plots/prediction_scatter.png
+  docs/evaluation_plots/per_pass_accuracy.png
+  docs/evaluation_plots/savings_vs_quality.png
+
+Usage:
+    python3 scripts/evaluate.py \\
+        --eval-dir testcases/evaluation \\
+        --models-dir models \\
+        --plugin build/IRComplexityEstimator.so \\
+        --docs-dir docs
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import joblib
+import matplotlib
+import numpy as np
+import pandas as pd
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+# Per-pass targets the model was trained on (issue #18). LICM is a loop
+# pass and is intentionally not timed, so it has no model.
+PER_PASS_TARGETS = ["time_GVNPass", "time_LoopVectorizePass",
+                    "time_SLPVectorizerPass"]
+LOG_PRED_CLIP = 20.0  # matches train_model.py / predict.py
+EXEC_REPS = 5         # binary timing repetitions; the minimum is reported
+
+
+def log(msg: str) -> None:
+    print(f"[evaluate] {msg}", flush=True)
+
+
+def find_tool(candidates: list[str]) -> str | None:
+    from shutil import which
+    for name in candidates:
+        if which(name):
+            return name
+    return None
+
+
+def run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+# --------------------------------------------------------------------------
+# model loading / prediction
+# --------------------------------------------------------------------------
+def load_models(models_dir: Path):
+    meta = json.loads((models_dir / "training_metadata.json").read_text())
+    mf = meta["model_files"]
+    scaler = joblib.load(models_dir / mf["feature_scaler"])
+    total = joblib.load(models_dir / mf["total_time_linear"])
+    per_pass = {}
+    for target, fname in mf.get("per_pass", {}).items():
+        path = models_dir / fname
+        if path.is_file():
+            per_pass[target] = joblib.load(path)
+    return meta["features"], scaler, total, per_pass
+
+
+def feature_matrix(funcs: list[dict], features: list[str]) -> np.ndarray:
+    rows = [[float(f.get(name, 0) or 0) for name in features] for f in funcs]
+    return np.asarray(rows, dtype=float)
+
+
+def predict_us(model, scaled: np.ndarray) -> np.ndarray:
+    pred_log = np.clip(model.predict(scaled), 0.0, LOG_PRED_CLIP)
+    return np.clip(np.expm1(pred_log), 0.0, None)
+
+
+# --------------------------------------------------------------------------
+# metrics
+# --------------------------------------------------------------------------
+def regression_metrics(actual: np.ndarray, predicted: np.ndarray) -> dict:
+    actual = np.asarray(actual, dtype=float)
+    predicted = np.asarray(predicted, dtype=float)
+    err = predicted - actual
+    ss_res = float(np.sum(err ** 2))
+    ss_tot = float(np.sum((actual - actual.mean()) ** 2))
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    mae = float(np.mean(np.abs(err)))
+    rmse = float(np.sqrt(np.mean(err ** 2)))
+    mask = actual > 0
+    mape = (float(np.mean(np.abs(err[mask] / actual[mask])) * 100)
+            if mask.any() else float("nan"))
+    return {"r2": r2, "mae": mae, "rmse": rmse, "mape": mape}
+
+
+# --------------------------------------------------------------------------
+# per-file pipeline
+# --------------------------------------------------------------------------
+def per_function_time(csv_path: Path) -> pd.DataFrame:
+    if not csv_path.is_file():
+        return pd.DataFrame(columns=["function_name", "pass_name", "time_us"])
+    return pd.read_csv(csv_path)
+
+
+def time_binary(binary: Path, reps: int) -> tuple[float, str]:
+    """Run a binary `reps` times; return (min wall seconds, stdout)."""
+    best = float("inf")
+    output = ""
+    for _ in range(reps):
+        start = time.perf_counter()
+        proc = run([str(binary)])
+        elapsed = time.perf_counter() - start
+        best = min(best, elapsed)
+        output = proc.stdout
+    return best, output
+
+
+def process_file(c_file: Path, clang: str, opt: str, plugin: Path,
+                 features: list[str], scaler, total_model, per_pass_models,
+                 work: Path) -> dict | None:
+    """Run the whole baseline/adaptive evaluation for one C file."""
+    name = c_file.stem
+    ll = work / f"{name}.ll"
+    feat_json = work / f"{name}.features.json"
+    base_csv = work / f"{name}.baseline.csv"
+    adap_csv = work / f"{name}.adaptive.csv"
+    pred_json = work / f"{name}.predictions.json"
+    base_bc = work / f"{name}.baseline.bc"
+    adap_bc = work / f"{name}.adaptive.bc"
+    base_bin = work / f"{name}.baseline.bin"
+    adap_bin = work / f"{name}.adaptive.bin"
+
+    # 1. compile to IR (optnone disabled so the O2 pipeline actually runs)
+    r = run([clang, "-O0", "-Xclang", "-disable-O0-optnone",
+             "-emit-llvm", "-S", str(c_file), "-o", str(ll)])
+    if r.returncode != 0:
+        log(f"ERROR: clang failed for {c_file.name}: {r.stderr.strip()}")
+        return None
+
+    # 2. extract features
+    r = run([opt, "-load-pass-plugin", str(plugin), "-passes=ir-complexity",
+             f"-complexity-output={feat_json}", "-disable-output", str(ll)])
+    if r.returncode != 0 or not feat_json.is_file():
+        log(f"ERROR: feature extraction failed for {c_file.name}")
+        return None
+    funcs = json.loads(feat_json.read_text())
+    if not funcs:
+        log(f"WARNING: {c_file.name} has no functions — skipping")
+        return None
+
+    # 3. baseline O2 run (timed)
+    t0 = time.perf_counter()
+    r = run([opt, "-load-pass-plugin", str(plugin), "-passes=default<O2>",
+             f"-timing-output={base_csv}", str(ll), "-o", str(base_bc)])
+    baseline_compile_s = time.perf_counter() - t0
+    if r.returncode != 0:
+        log(f"ERROR: baseline O2 failed for {c_file.name}")
+        return None
+
+    # 4. predictions
+    scaled = scaler.transform(feature_matrix(funcs, features))
+    total_pred = predict_us(total_model, scaled)
+    predictions = []
+    for i, fn in enumerate(funcs):
+        predictions.append({"function_name": fn["function_name"],
+                            "complexity_tier": "low" if total_pred[i] < 500
+                            else "medium" if total_pred[i] < 5000 else "high"})
+    pred_json.write_text(json.dumps(predictions))
+
+    # 5. adaptive run (timed)
+    env = {**os.environ, "COMPLEXITY_PREDICTIONS": str(pred_json)}
+    t0 = time.perf_counter()
+    r = run([opt, "-load-pass-plugin", str(plugin), "-passes=adaptive-pipeline",
+             f"-timing-output={adap_csv}", str(ll), "-o", str(adap_bc)],
+            env=env)
+    adaptive_compile_s = time.perf_counter() - t0
+    if r.returncode != 0:
+        log(f"ERROR: adaptive run failed for {c_file.name}")
+        return None
+
+    # 6. build binaries
+    ok = True
+    for bc, binary in ((base_bc, base_bin), (adap_bc, adap_bin)):
+        rr = run([clang, str(bc), "-o", str(binary)])
+        ok = ok and rr.returncode == 0
+    if not ok:
+        log(f"WARNING: {c_file.name} did not link to a binary — "
+            f"skipping its quality measurement")
+        base_ms = adap_ms = None
+        correct = None
+    else:
+        # 7. measure execution time + correctness
+        base_s, base_out = time_binary(base_bin, EXEC_REPS)
+        adap_s, adap_out = time_binary(adap_bin, EXEC_REPS)
+        base_ms = base_s * 1000.0
+        adap_ms = adap_s * 1000.0
+        correct = base_out == adap_out
+
+    # actual per-function / per-pass times from the baseline timing CSV
+    base_timing = per_function_time(base_csv)
+    actual_total = base_timing.groupby("function_name")["time_us"].sum() \
+        if not base_timing.empty else pd.Series(dtype=float)
+
+    func_records = []
+    for i, fn in enumerate(funcs):
+        fname = fn["function_name"]
+        func_records.append({
+            "function_name": fname,
+            "source_file": c_file.name,
+            "predicted_us": float(total_pred[i]),
+            "actual_us": float(actual_total.get(fname, 0.0)),
+        })
+
+    return {
+        "file": c_file.name,
+        "functions": func_records,
+        "baseline_timing": base_timing,
+        "scaled": scaled,
+        "func_names": [f["function_name"] for f in funcs],
+        "baseline_compile_ms": baseline_compile_s * 1000.0,
+        "adaptive_compile_ms": adaptive_compile_s * 1000.0,
+        "baseline_exec_ms": base_ms,
+        "adaptive_exec_ms": adap_ms,
+        "correct": correct,
+    }
+
+
+# --------------------------------------------------------------------------
+# plotting
+# --------------------------------------------------------------------------
+def plot_scatter(records: list[dict], r2: float, out: Path) -> None:
+    fig, ax = plt.subplots(figsize=(8, 7))
+    normal_x, normal_y, fail_x, fail_y, fail_names = [], [], [], [], []
+    for rec in records:
+        x = max(rec["actual_us"], 1.0)
+        y = max(rec["predicted_us"], 1.0)
+        if "test07" in rec["source_file"]:
+            fail_x.append(x); fail_y.append(y)
+            fail_names.append(rec["function_name"])
+        else:
+            normal_x.append(x); normal_y.append(y)
+
+    lo = 1.0
+    hi = max([1.0] + normal_x + normal_y + fail_x + fail_y) * 1.5
+    ax.plot([lo, hi], [lo, hi], "k--", linewidth=1,
+            label="perfect prediction")
+    ax.scatter(normal_x, normal_y, c="#1f77b4", s=55, alpha=0.8,
+               label="evaluation functions")
+    if fail_x:
+        ax.scatter(fail_x, fail_y, c="#d62728", s=110, marker="X",
+                   label="failure case (test07)", zorder=5)
+        for fx, fy, fn in zip(fail_x, fail_y, fail_names):
+            ax.annotate(f"  {fn} (failure case)", (fx, fy),
+                        fontsize=9, color="#d62728", va="center")
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlim(lo, hi)
+    ax.set_ylim(lo, hi)
+    ax.set_xlabel("Actual total compile time (µs)")
+    ax.set_ylabel("Predicted total compile time (µs)")
+    ax.set_title(f"Predicted vs actual compile time  (R² = {r2:.3f})")
+    ax.legend(loc="lower right")
+    ax.grid(True, which="both", linestyle=":", alpha=0.4)
+    fig.tight_layout()
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_per_pass(per_pass_mape: dict, out: Path) -> None:
+    fig, ax = plt.subplots(figsize=(8, 5))
+    names = list(per_pass_mape.keys())
+    values = [per_pass_mape[n] for n in names]
+    ax.bar(names, values, color="#ff7f0e")
+    ax.set_ylabel("MAPE (%)")
+    ax.set_title("Per-pass prediction accuracy (lower is better)")
+    for i, v in enumerate(values):
+        ax.text(i, v, f"{v:.0f}%", ha="center", va="bottom", fontsize=9)
+    fig.tight_layout()
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_savings_vs_quality(per_file: list[dict], out: Path) -> None:
+    fig, ax = plt.subplots(figsize=(8, 6))
+    xs = [r["compile_savings_pct"] for r in per_file]
+    ys = [r["quality_regression_pct"] for r in per_file]
+    ax.scatter(xs, ys, c="#2ca02c", s=70)
+    for r in per_file:
+        ax.annotate(f"  {r['file']}",
+                    (r["compile_savings_pct"], r["quality_regression_pct"]),
+                    fontsize=8, va="center")
+    ax.axhline(0.0, color="black", linewidth=0.8)
+    ax.axvline(0.0, color="black", linewidth=0.8)
+    ax.set_xlabel("Compile-time savings (%)")
+    ax.set_ylabel("Code quality regression (%)")
+    ax.set_title("Adaptive pipeline: compile savings vs quality regression")
+    ax.grid(True, linestyle=":", alpha=0.4)
+    fig.tight_layout()
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the evaluation suite.")
+    parser.add_argument("--eval-dir", default="testcases/evaluation")
+    parser.add_argument("--models-dir", default="models")
+    parser.add_argument("--plugin", default="build/IRComplexityEstimator.so")
+    parser.add_argument("--docs-dir", default="docs")
+    args = parser.parse_args()
+
+    eval_dir = Path(args.eval_dir)
+    models_dir = Path(args.models_dir)
+    plugin = Path(args.plugin).resolve()
+    docs_dir = Path(args.docs_dir)
+    plots_dir = docs_dir / "evaluation_plots"
+
+    if not (models_dir / "training_metadata.json").is_file():
+        log(f"ERROR: no trained model in {models_dir} — run training first")
+        return 1
+    if not plugin.is_file():
+        log(f"ERROR: plugin not found: {plugin} — run ./build.sh first")
+        return 1
+
+    clang = find_tool(["clang-17", "clang"])
+    opt = find_tool(["opt-17", "opt"])
+    if not clang or not opt:
+        log("ERROR: clang-17/opt-17 not found — run scripts/setup_env.sh")
+        return 1
+
+    c_files = sorted(eval_dir.glob("*.c"))
+    if not c_files:
+        log(f"ERROR: no .c files in {eval_dir}")
+        return 1
+
+    features, scaler, total_model, per_pass_models = load_models(models_dir)
+
+    results = []
+    with tempfile.TemporaryDirectory(prefix="evaluate_") as tmp:
+        work = Path(tmp)
+        for c_file in c_files:
+            log(f"evaluating {c_file.name}")
+            res = process_file(c_file, clang, opt, plugin, features, scaler,
+                               total_model, per_pass_models, work)
+            if res is not None:
+                results.append(res)
+
+    if not results:
+        log("ERROR: no evaluation files processed successfully")
+        return 1
+
+    # --- Mode 1: prediction accuracy -------------------------------------
+    func_records = [fr for res in results for fr in res["functions"]]
+    actual = np.array([fr["actual_us"] for fr in func_records])
+    predicted = np.array([fr["predicted_us"] for fr in func_records])
+    overall = regression_metrics(actual, predicted)
+
+    # per-pass MAPE: predicted (per-pass model) vs actual (timing CSV)
+    per_pass_mape = {}
+    for target, model in per_pass_models.items():
+        pass_name = target[len("time_"):]
+        pred_list, act_list = [], []
+        for res in results:
+            timing = res["baseline_timing"]
+            by_pass = (timing[timing["pass_name"] == pass_name]
+                       .groupby("function_name")["time_us"].sum()
+                       if not timing.empty else pd.Series(dtype=float))
+            pp_pred = predict_us(model, res["scaled"])
+            for i, fname in enumerate(res["func_names"]):
+                pred_list.append(pp_pred[i])
+                act_list.append(float(by_pass.get(fname, 0.0)))
+        per_pass_mape[pass_name] = regression_metrics(
+            np.array(act_list), np.array(pred_list))["mape"]
+
+    # --- Mode 2: adaptive effectiveness ----------------------------------
+    per_file = []
+    for res in results:
+        bc = res["baseline_compile_ms"]
+        ac = res["adaptive_compile_ms"]
+        savings = (bc - ac) / bc * 100.0 if bc > 0 else 0.0
+        be, ae = res["baseline_exec_ms"], res["adaptive_exec_ms"]
+        if be and be > 0 and ae is not None:
+            regression = (ae - be) / be * 100.0
+        else:
+            regression = 0.0
+        per_file.append({
+            "file": res["file"],
+            "baseline_compile_ms": bc,
+            "adaptive_compile_ms": ac,
+            "compile_savings_pct": savings,
+            "baseline_exec_ms": be,
+            "adaptive_exec_ms": ae,
+            "quality_regression_pct": regression,
+            "output_matches": res["correct"],
+        })
+
+    total_base_compile = sum(r["baseline_compile_ms"] for r in per_file)
+    total_adap_compile = sum(r["adaptive_compile_ms"] for r in per_file)
+    compile_savings_pct = ((total_base_compile - total_adap_compile)
+                           / total_base_compile * 100.0
+                           if total_base_compile > 0 else 0.0)
+    avg_quality_regression = float(np.mean(
+        [r["quality_regression_pct"] for r in per_file]))
+    over_5pct = sum(1 for r in per_file if r["quality_regression_pct"] > 5.0)
+
+    # --- write outputs ---------------------------------------------------
+    plots_dir.mkdir(parents=True, exist_ok=True)
+    plot_scatter(func_records, overall["r2"],
+                 plots_dir / "prediction_scatter.png")
+    plot_per_pass(per_pass_mape, plots_dir / "per_pass_accuracy.png")
+    plot_savings_vs_quality(per_file, plots_dir / "savings_vs_quality.png")
+
+    results_json = {
+        "prediction_accuracy": {
+            "model": "LinearRegression",
+            "n_functions": len(func_records),
+            "r2": overall["r2"],
+            "mae_us": overall["mae"],
+            "rmse_us": overall["rmse"],
+            "mape_pct": overall["mape"],
+            "per_pass_mape_pct": per_pass_mape,
+            "functions": func_records,
+        },
+        "adaptive_effectiveness": {
+            "compile_time_savings_pct": compile_savings_pct,
+            "avg_quality_regression_pct": avg_quality_regression,
+            "files_over_5pct_regression": over_5pct,
+            "n_files": len(per_file),
+            "per_file": per_file,
+        },
+    }
+    (docs_dir / "evaluation_results.json").write_text(
+        json.dumps(results_json, indent=2))
+
+    log(f"wrote {docs_dir}/evaluation_results.json and 3 plots in {plots_dir}/")
+
+    # --- required stdout block (copy-paste into EVALUATION.md) -----------
+    print()
+    print("=== PREDICTION ACCURACY ===")
+    print("Model: LinearRegression")
+    print(f"R²: {overall['r2']:.2f}   MAE: {overall['mae']:.0f}µs   "
+          f"RMSE: {overall['rmse']:.0f}µs   MAPE: {overall['mape']:.1f}%")
+    print("=== ADAPTIVE PIPELINE ===")
+    print(f"Compile-time savings: {compile_savings_pct:.1f}%")
+    print(f"Code quality regression (avg): {avg_quality_regression:.1f}%")
+    print(f"Functions with >5% quality regression: "
+          f"{over_5pct} / {len(per_file)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testcases/evaluation/test01_arith_eval.c
+++ b/testcases/evaluation/test01_arith_eval.c
@@ -1,0 +1,34 @@
+/* test01_arith_eval.c
+ *
+ * Held-out evaluation case (NOT used in training): scalar arithmetic leaf
+ * functions plus a small driver loop. Low static complexity — exercises
+ * the low end of the model's prediction range.
+ *
+ * Self-contained runnable program: main() exercises every function and
+ * prints a deterministic checksum so baseline and adaptive builds can be
+ * compared for correctness.
+ */
+#include <stdio.h>
+
+static int poly(int x) {
+    return 3 * x * x + 2 * x + 7;
+}
+
+static int blend(int a, int b) {
+    return ((a * 5) - (b * 3)) ^ (a + b);
+}
+
+static int fold(int seed, int steps) {
+    int acc = seed;
+    for (int i = 0; i < steps; i++)
+        acc = blend(acc, poly(i & 0x3F));
+    return acc;
+}
+
+int main(void) {
+    long checksum = 0;
+    for (int run = 0; run < 4000; run++)
+        checksum += fold(run, 1024);
+    printf("test01 checksum=%ld\n", checksum);
+    return 0;
+}

--- a/testcases/evaluation/test02_loops_eval.c
+++ b/testcases/evaluation/test02_loops_eval.c
@@ -1,0 +1,38 @@
+/* test02_loops_eval.c
+ *
+ * Held-out evaluation case (NOT used in training): nested-loop numeric
+ * kernels, including a 4-level loop nest in convolve(). Exercises the
+ * high end of the loop-depth feature.
+ *
+ * Self-contained runnable program with a deterministic checksum.
+ */
+#include <stdio.h>
+
+#define DIM 24
+
+static void fill(int *m, int dim, int seed) {
+    for (int i = 0; i < dim; i++)
+        for (int j = 0; j < dim; j++)
+            m[i * dim + j] = (i * 7 + j * 13 + seed) & 0xFF;
+}
+
+static long convolve(const int *m, int dim) {
+    long sum = 0;
+    for (int i = 1; i < dim - 1; i++)
+        for (int j = 1; j < dim - 1; j++)
+            for (int di = -1; di <= 1; di++)
+                for (int dj = -1; dj <= 1; dj++)
+                    sum += m[(i + di) * dim + (j + dj)];
+    return sum;
+}
+
+int main(void) {
+    int grid[DIM * DIM];
+    long total = 0;
+    for (int run = 0; run < 3000; run++) {
+        fill(grid, DIM, run);
+        total += convolve(grid, DIM);
+    }
+    printf("test02 total=%ld\n", total);
+    return 0;
+}

--- a/testcases/evaluation/test03_branches_eval.c
+++ b/testcases/evaluation/test03_branches_eval.c
@@ -1,0 +1,37 @@
+/* test03_branches_eval.c
+ *
+ * Held-out evaluation case (NOT used in training): branch-heavy control
+ * flow with no loops in the leaf functions. Exercises the cyclomatic
+ * complexity feature.
+ *
+ * Self-contained runnable program with a deterministic checksum.
+ */
+#include <stdio.h>
+
+static int classify(int v) {
+    if (v < 0)        return 0;
+    else if (v < 16)  return 1;
+    else if (v < 64)  return 2;
+    else if (v < 128) return 3;
+    else if (v < 192) return 4;
+    else if (v < 240) return 5;
+    else              return 6;
+}
+
+static int score(int a, int b, int c) {
+    int s = 0;
+    if (a > b)  s += 3; else s -= 1;
+    if (b > c)  s += 5; else s -= 2;
+    if (a > c)  s += 7; else s -= 3;
+    if ((a ^ b) & 1) s *= 2;
+    if ((b ^ c) & 2) s += classify(a);
+    return s;
+}
+
+int main(void) {
+    long acc = 0;
+    for (int i = 0; i < 3000000; i++)
+        acc += score(i & 0xFF, (i >> 3) & 0xFF, (i >> 6) & 0xFF);
+    printf("test03 acc=%ld\n", acc);
+    return 0;
+}

--- a/testcases/evaluation/test04_pointers_eval.c
+++ b/testcases/evaluation/test04_pointers_eval.c
@@ -1,0 +1,39 @@
+/* test04_pointers_eval.c
+ *
+ * Held-out evaluation case (NOT used in training): pointer-heavy buffer
+ * processing with loads, stores and pointer arithmetic. Exercises the
+ * alias-proxy-density feature.
+ *
+ * Self-contained runnable program with a deterministic checksum.
+ */
+#include <stdio.h>
+
+#define LEN 256
+
+static void scale_shift(int *buf, int len, int factor, int shift) {
+    for (int i = 0; i < len; i++)
+        buf[i] = buf[i] * factor + shift;
+}
+
+static long reduce_pairs(const int *a, const int *b, int len) {
+    long sum = 0;
+    for (int i = 0; i < len; i++)
+        sum += (long)a[i] * b[len - 1 - i];
+    return sum;
+}
+
+int main(void) {
+    int x[LEN];
+    int y[LEN];
+    long total = 0;
+    for (int run = 0; run < 20000; run++) {
+        for (int i = 0; i < LEN; i++) {
+            x[i] = (i + run) & 0xFF;
+            y[i] = (i ^ run) & 0xFF;
+        }
+        scale_shift(x, LEN, 3, run & 7);
+        total += reduce_pairs(x, y, LEN);
+    }
+    printf("test04 total=%ld\n", total);
+    return 0;
+}

--- a/testcases/evaluation/test05_structs_eval.c
+++ b/testcases/evaluation/test05_structs_eval.c
@@ -1,0 +1,48 @@
+/* test05_structs_eval.c
+ *
+ * Held-out evaluation case (NOT used in training): nested-struct data
+ * manipulation. Exercises the type-complexity feature.
+ *
+ * Self-contained runnable program with a deterministic checksum.
+ */
+#include <stdio.h>
+
+struct Point {
+    int x;
+    int y;
+};
+
+struct Shape {
+    struct Point pts[4];
+    int weight;
+};
+
+static void build(struct Shape *s, int seed) {
+    for (int i = 0; i < 4; i++) {
+        s->pts[i].x = (seed * (i + 1)) & 0x7F;
+        s->pts[i].y = (seed + i * 17) & 0x7F;
+    }
+    s->weight = (seed & 7) + 1;
+}
+
+static long perimeter(const struct Shape *s) {
+    long p = 0;
+    for (int i = 0; i < 4; i++) {
+        int j = (i + 1) & 3;
+        int dx = s->pts[i].x - s->pts[j].x;
+        int dy = s->pts[i].y - s->pts[j].y;
+        p += (dx < 0 ? -dx : dx) + (dy < 0 ? -dy : dy);
+    }
+    return p * s->weight;
+}
+
+int main(void) {
+    struct Shape s;
+    long total = 0;
+    for (int run = 0; run < 1000000; run++) {
+        build(&s, run);
+        total += perimeter(&s);
+    }
+    printf("test05 total=%ld\n", total);
+    return 0;
+}

--- a/testcases/evaluation/test06_recursion_eval.c
+++ b/testcases/evaluation/test06_recursion_eval.c
@@ -1,0 +1,33 @@
+/* test06_recursion_eval.c
+ *
+ * Held-out evaluation case (NOT used in training): recursive functions
+ * that the inliner cannot fully expand. Exercises the call-site feature
+ * and recursion handling.
+ *
+ * Self-contained runnable program with a deterministic checksum.
+ */
+#include <stdio.h>
+
+static long collatz_len(long n) {
+    if (n <= 1)
+        return 0;
+    if (n & 1)
+        return 1 + collatz_len(3 * n + 1);
+    return 1 + collatz_len(n / 2);
+}
+
+static int gcd(int a, int b) {
+    if (b == 0)
+        return a;
+    return gcd(b, a % b);
+}
+
+int main(void) {
+    long acc = 0;
+    for (int i = 1; i < 60000; i++) {
+        acc += collatz_len(i);
+        acc += gcd(i, i / 2 + 1);
+    }
+    printf("test06 acc=%ld\n", acc);
+    return 0;
+}

--- a/testcases/evaluation/test07_analysis.md
+++ b/testcases/evaluation/test07_analysis.md
@@ -1,0 +1,79 @@
+# Failure Case Analysis — `test07_failure_case.c`
+
+## Summary
+
+`misleading_complex()` is a function the prediction model gets badly
+wrong. Statically it looks like an expensive, HIGH-tier compilation; in
+reality it compiles very quickly. This document explains why the model
+fails, which optimization pass short-circuits the work, what feature
+would let the model see through the illusion, and whether the failure is
+fixable without redesigning the feature set.
+
+## Which features caused the over-prediction
+
+The function presents three of the model's strongest cost signals at
+high values. Its body is a long straight-line block of arithmetic — about
+nineteen named temporaries plus a wide reduction — wrapped in a 3-level
+loop nest, so `instruction_count` is large (well above the training-set
+mean) and `max_loop_depth` is 3. Because the body also writes to and
+reads from the `out` accumulator, `loop_instruction_ratio` is close to
+1.0: almost every instruction lives inside a loop. `instruction_count` is
+the single largest positive coefficient in the trained `LinearRegression`
+model, and loop depth is the feature domain knowledge says matters most.
+The model dutifully multiplies these together and predicts a long,
+HIGH-tier compilation dominated by loop vectorisation and LICM.
+
+The static feature extractor has no way of knowing that the operands are
+all literal constants. It counts an `add` of two constants and an `add`
+of two loop-varying values identically — both are one instruction, both
+sit at loop depth 3. The features describe the *shape* of the unoptimised
+IR, not the *amount of real work* that survives optimization. For this
+function the shape is large and the surviving work is almost nothing, and
+the model only sees the shape.
+
+## Which pass short-circuits the expensive work
+
+Every temporary in the loop body (`a` through `z`) is computed purely
+from integer literals and earlier constant temporaries. None of them
+depend on the loop induction variables `i`, `j`, `k` or on any value
+loaded from memory. The first run of **InstCombine** together with
+**SCCP** (Sparse Conditional Constant Propagation) constant-folds the
+entire block: the nineteen temporaries and the wide final sum collapse to
+one integer constant. Dead code elimination then removes all the folded
+instructions. After that single cheap simplification pass the loop body
+is just `out += <constant>`.
+
+The expensive passes the model is most afraid of never get any real work.
+**LICM** has one trivial invariant to consider; **LoopVectorize** inspects
+a loop whose body is a single constant add and a memory accumulate and
+quickly decides there is nothing worth vectorising; **GVN** has almost no
+values to number. The cost of compiling this function is therefore
+dominated by the one cheap constant-folding pass, not by the loop
+optimisations — the opposite of what the feature vector implies. Measured
+against the model's HIGH-tier prediction, the actual per-pass total is
+smaller by well over 5×.
+
+## What feature would fix this, and is it fixable
+
+The missing signal is *how much of the IR is constant or loop-invariant*.
+A concrete new feature would be a **loop-invariant instruction ratio**:
+the fraction of instructions inside loops whose operands are all
+constants or are themselves loop-invariant. This is cheap to compute in
+the existing `IRComplexityPass` — LLVM already exposes `Loop::isLoopInvariant()`
+and a constant check on operands — and it does not require running any
+optimization. For `misleading_complex()` this ratio would be close to
+1.0, and a model trained with it would learn to discount
+`instruction_count` and `max_loop_depth` heavily when the invariant ratio
+is high. A related feature, a *constant-operand ratio* over all
+instructions, would catch the same pattern.
+
+This particular failure mode **is fixable without redesigning the feature
+set** — it only needs one or two additional features of the same kind
+(cheap, static, computed from unoptimised IR). The deeper limitation is
+fundamental and not fixable this way: the model predicts post-optimization
+cost from pre-optimization IR, so any pass with a data-dependent
+early-exit can defeat any purely static feature set. The loop-invariant
+ratio closes *this* gap; a function whose work is eliminated by, say,
+profile-guided dead-path removal would need a different feature again.
+Honest scope: static features can make the model robust to common
+constant-folding illusions, but they cannot make it exact.

--- a/testcases/evaluation/test07_failure_case.c
+++ b/testcases/evaluation/test07_failure_case.c
@@ -1,0 +1,62 @@
+/* test07_failure_case.c
+ *
+ * FAILURE CASE — see test07_analysis.md for the full discussion.
+ *
+ * This function looks expensive to the static feature extractor: a
+ * 3-level loop nest with a long straight-line body gives it a high
+ * instruction_count, max_loop_depth = 3 and a non-trivial memory-op
+ * density. The model therefore predicts an expensive, HIGH-tier
+ * compilation.
+ *
+ * In reality every value in the loop body is a compile-time constant.
+ * InstCombine / SCCP fold the entire body to a single constant almost
+ * immediately, so the expensive loop passes (LoopVectorize, LICM, GVN)
+ * never see any real work and the function compiles very fast. The
+ * prediction error is large (predicted >> actual).
+ *
+ * Self-contained runnable program with a deterministic checksum.
+ */
+#include <stdio.h>
+
+int misleading_complex(int n) {
+    int out = 0;
+    for (int i = 0; i < n; i++) {
+        for (int j = 0; j < n; j++) {
+            for (int k = 0; k < n; k++) {
+                /* Every line below is loop-invariant and constant: the
+                 * operands never depend on i, j, k or any memory. The
+                 * compiler folds this whole block to one constant before
+                 * the expensive loop optimisations run. */
+                int a = 42;
+                int b = a * 2;
+                int c = b + a * 3;
+                int d = c - b + a;
+                int e = d * 2 + c;
+                int f = e + d - a;
+                int g = f * 3 - e;
+                int h = g + f + e + d;
+                int p = h + g - c;
+                int q = p * 2 - h;
+                int r = q + p + a;
+                int s = r - q + b;
+                int t = s * 2 + r;
+                int u = t + s - d;
+                int v = u * 3 - t;
+                int w = v + u + e + f;
+                int x = w - v + g;
+                int y = x * 2 + w;
+                int z = y + x - h;
+                out += a + b + c + d + e + f + g + h + p + q
+                     + r + s + t + u + v + w + x + y + z;
+            }
+        }
+    }
+    return out;
+}
+
+int main(void) {
+    /* n is small at run time, but the function is compiled generically:
+     * the optimiser cannot assume any particular value of n. */
+    printf("test07 result=%d\n", misleading_complex(12));
+    return 0;
+}

--- a/testcases/evaluation/test08_mixed_eval.c
+++ b/testcases/evaluation/test08_mixed_eval.c
@@ -1,0 +1,48 @@
+/* test08_mixed_eval.c
+ *
+ * Held-out evaluation case (NOT used in training): a mixed workload
+ * combining a switch, loops, branches, calls and memory traffic in one
+ * larger program. Exercises several features at once.
+ *
+ * Self-contained runnable program with a deterministic checksum.
+ */
+#include <stdio.h>
+
+#define N 128
+
+static int transform(int v, int mode) {
+    switch (mode & 3) {
+        case 0:  return v + 1;
+        case 1:  return v * 2;
+        case 2:  return v ^ 0x5A;
+        default: return (v >> 1) + 3;
+    }
+}
+
+static long process(int *buf, int len) {
+    long sum = 0;
+    for (int i = 0; i < len; i++) {
+        buf[i] = transform(buf[i], i);
+        if (buf[i] & 1)
+            sum += buf[i];
+        else
+            sum -= buf[i] / 2;
+    }
+    for (int i = 0; i < len; i++)
+        for (int j = i + 1; j < len; j++)
+            if (buf[i] > buf[j])
+                sum += 1;
+    return sum;
+}
+
+int main(void) {
+    int buf[N];
+    long total = 0;
+    for (int run = 0; run < 8000; run++) {
+        for (int i = 0; i < N; i++)
+            buf[i] = (i * 31 + run) & 0xFF;
+        total += process(buf, N);
+    }
+    printf("test08 total=%ld\n", total);
+    return 0;
+}


### PR DESCRIPTION
Implements Milestone 7 (Evaluation) as 2 per-issue commits.

## Issues
- **#25** `test07_failure_case.c` + `test07_analysis.md` — a documented prediction failure: a function that looks expensive statically but compiles fast because InstCombine/SCCP fold its loop-invariant body.
- **#24** `scripts/evaluate.py` — measures prediction accuracy (R²/MAE/RMSE/MAPE + per-pass MAPE) and adaptive-pipeline effectiveness (compile-time savings + binary execution-speed regression), emitting `evaluation_results.json` and three plots. Also adds seven held-out, self-contained evaluation testcases — `#24`'s acceptance criteria require an 8-case `testcases/evaluation/` corpus, but only `#25` defined `test07`.

## Verification (Docker, Ubuntu 22.04 + LLVM 17.0.6)
- All 8 evaluation testcases compile cleanly with `clang-17 -O0 -Wall -Wextra -std=c99` and run with deterministic output.
- `evaluate.py` runs on all 8 cases, produces `docs/evaluation_results.json` plus the three plots, and prints the EVALUATION.md summary block.
- Scatter plot includes the perfect-prediction diagonal; the failure case is highlighted as a red X with an annotation.
- **Failure case: 69.6× prediction error** (predicted 120,917 µs vs actual 1,738 µs) — well above the ≥5× requirement.

## Honest evaluation findings
- Prediction R² is strongly negative and MAPE high: the model was trained on only 31 samples (the known small-dataset limitation from M5). `evaluate.py` reports this honestly rather than masking it.
- The adaptive pipeline shows a real code-quality regression. By design (#21) it runs `buildFunctionSimplificationPipeline`, which omits the inliner; for call-heavy hot loops in the eval programs that costs measurable execution speed. This is a faithful, honest measurement of the spec'd design's trade-off.